### PR TITLE
[FEAT] image upload API 기능 구현

### DIFF
--- a/route/images/images.crtl.js
+++ b/route/images/images.crtl.js
@@ -1,1 +1,11 @@
 'use strict';
+
+const image = (req, res) => {
+    const file = req.file;
+    console.log(file);
+    res.send({
+        imageUrl: file.path,
+    });
+};
+
+module.exports = { image };

--- a/route/images/images.js
+++ b/route/images/images.js
@@ -1,1 +1,35 @@
 'use strict';
+
+// modules
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const upload = multer({
+    storage: multer.diskStorage({
+        destination: (req, res, cb) => {
+            cb(null, 'uploads/imgs');
+        },
+        // 22.08.12 by Steve / To-do: user_id를 활용한 식별 가능한 파일명 작업
+        filename: (req, file, cb) => {
+            cb(null, file.originalname);
+        },
+        fileFilter: (req, file, cb) => {
+            const ext = path.extname(file.originalname);
+            if(ext !== '.jpeg' || '.jpg' || '.png') {
+                return cb(null, false);
+            }
+            return cb(null, true);
+        },
+        limits: {
+            fileSize: 20 * 1024 *1024
+        },
+    }),
+});
+
+// controller
+const ctrl = require('./images.crtl');
+
+// router
+router.post('/', upload.single('image'), ctrl.image);
+
+module.exports = router;

--- a/route/index.js
+++ b/route/index.js
@@ -10,7 +10,7 @@ const images = require('./images/images');
 const data = require('./data/data');
 
 router.use('/users', users);
-router.use('/images', images);
+// router.use('/images', images);
 // router.use('/data', data);
 
 module.exports = router;


### PR DESCRIPTION
## `8-feat-image-upload-기능구현` → `main` (Closes #8)✨

## 요약✏
* image upload API 기능 구현

## 구현 내용📝
* multer middleware 사용
* single image upload로 설정
* original filaname을 파일 저장

## Screenshots🎨
![image](https://user-images.githubusercontent.com/46704032/184287703-59290638-e30f-4ca0-a730-83ab997f2af8.png)

## 관련 이슈🎯
* 현재는 single image upload로 설정하였으며, multi image에 대한 기능에 대한 논의 필요함
* filename은 현재 original filename으로 설정하였으나, user_id 및 upload 일시를 추가한 식별 가능한 filename 기능 추가 필요함
* image 파일이 upload되는 조건 확인 필요함 
* 이미지 저장은 S3 storage 서버 구축 필요함